### PR TITLE
Use Dependency Review to Deny `pkg:nuget/Moq@4.20.0` and `pkg:nuget/Moq@4.20.1`

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -19,4 +19,4 @@ jobs:
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@v3
         with: 
-          deny-packages: pkg:nuget/Moq
+          deny-packages: pkg:nuget/Moq@4.20.0, pkg:nuget/Moq@4.20.1

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -9,6 +9,7 @@ on: [pull_request]
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   dependency-review:
@@ -18,5 +19,6 @@ jobs:
         uses: actions/checkout@v3
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@v3
-        with: 
+        with:
           deny-packages: pkg:nuget/Moq@4.20.0, pkg:nuget/Moq@4.20.1
+          comment-summary-in-pr: true

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,22 @@
+# Dependency Review Action
+#
+# This Action will scan dependency manifest files that change as part of a Pull Request, surfacing known-vulnerable versions of the packages declared or updated in the PR. Once installed, if the workflow run is marked as required, PRs introducing known-vulnerable packages will be blocked from merging.
+#
+# Source repository: https://github.com/actions/dependency-review-action
+# Public documentation: https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-dependency-review#dependency-review-enforcement
+name: 'Dependency Review'
+on: [pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout Repository'
+        uses: actions/checkout@v3
+      - name: 'Dependency Review'
+        uses: actions/dependency-review-action@v3
+        with: 
+          deny-packages: pkg:nuget/Moq

--- a/Source/TailwindTraders.Mobile/UnitTests/UnitTests.csproj
+++ b/Source/TailwindTraders.Mobile/UnitTests/UnitTests.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
-    <PackageReference Include="Moq" Version="4.10.1" />
+    <PackageReference Include="Moq" Version="4.20.0" />
     <PackageReference Include="NUnit" Version="3.11.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
     <PackageReference Include="Refit" Version="4.6.107" />


### PR DESCRIPTION
See: https://github.com/moq/moq/issues/1372

https://github.com/octodemo/TailwindTraders-Mobile/blob/3b70b301090d199cb3b1ddfb5ecc7b47314d408f/.github/workflows/dependency-review.yml#L19-L22

- change config to `pkg:nuget/Moq` to blanket fail anytime Moq is added/updated.